### PR TITLE
Name switch on half change

### DIFF
--- a/src/controller/ui/gameplay/GUIBackup.java
+++ b/src/controller/ui/gameplay/GUIBackup.java
@@ -770,7 +770,7 @@ public class GUIBackup extends JFrame implements GCGUI, CommonGUI
     protected void updateHalf(AdvancedData data)
     {
         for (int i=0; i<2; i++) {
-//            name[i].setText(Teams.getNames(false)[data.team[i].teamNumber]);
+            name[i].setText(Teams.getNames(false)[data.team[i].teamNumber]);
         }
         firstHalf.setEnabled(ActionBoard.firstHalf.isLegal(data));
         secondHalf.setEnabled(ActionBoard.secondHalf.isLegal(data));


### PR DESCRIPTION
I don't know why this line was commented before
Without this fix the names of the teams are now swapped on the screen at the second half