### PR TITLE
Warnings for robots, Retake button + Misc

### DIFF
--- a/src/controller/action/ActionBoard.java
+++ b/src/controller/action/ActionBoard.java
@@ -63,6 +63,7 @@ public class ActionBoard {
     public static CornerKick[] cornerKick = new CornerKick[2];
     public static GoalKick[] goalKick = new GoalKick[2];
     public static ThrowIn[] throwIn = new ThrowIn[2];
+    public static RetakeGameInterruption[] retakeGameInterruptions = new RetakeGameInterruption[2];
 
     public static Manual[][] manualPen = Rules.league.isCoachAvailable ? new Manual[2][Rules.league.teamSize + 1] : new Manual[2][Rules.league.teamSize];
     public static Manual[][] manualUnpen = Rules.league.isCoachAvailable ? new Manual[2][Rules.league.teamSize + 1] : new Manual[2][Rules.league.teamSize];
@@ -105,6 +106,7 @@ public class ActionBoard {
             cornerKick[i] = new CornerKick(i);
             goalKick[i] = new GoalKick(i);
             throwIn[i] = new ThrowIn(i);
+            retakeGameInterruptions[i] = new RetakeGameInterruption(i);
         }
 
         clockReset = new ClockReset();

--- a/src/controller/action/ui/CardIncrease.java
+++ b/src/controller/action/ui/CardIncrease.java
@@ -24,6 +24,7 @@ public class CardIncrease extends GCAction {
         this.color = color;
     }
 
+
     private void giveRedCard(AdvancedData data){
         int currentCount = data.team[side.value()].player[player].redCardCount;
 
@@ -43,12 +44,31 @@ public class CardIncrease extends GCAction {
         }
 
         if (currentCount == 2){
+            data.team[side.value()].player[player].yellowCardCount = 0;
             giveRedCard(data);
+        }
+    }
+
+    private void giveWarningCard(AdvancedData data){
+        int currentCount = data.team[side.value()].player[player].warningCardCount;
+
+        if (currentCount < 2){
+            currentCount += 1;
+            data.team[side.value()].player[player].warningCardCount = (byte) currentCount;
+            Log.state(data, "Added warning card");
+        }
+
+        if (currentCount == 2){
+            data.team[side.value()].player[player].warningCardCount = 0;
+            giveYellowCard(data);
         }
     }
 
     @Override
     public void perform(AdvancedData data) {
+        if (this.color == Color.BLUE) {
+            giveWarningCard(data);
+        }
         if (this.color == Color.YELLOW) {
             giveYellowCard(data);
         }
@@ -59,7 +79,7 @@ public class CardIncrease extends GCAction {
 
     @Override
     public boolean isLegal(AdvancedData data) {
-        return true;
+        return data.team[side.value()].player[player].redCardCount != 1;
     }
 
 }

--- a/src/controller/action/ui/DropInPointsEvaluation.java
+++ b/src/controller/action/ui/DropInPointsEvaluation.java
@@ -20,7 +20,7 @@ public class DropInPointsEvaluation extends GCAction {
     @Override
     public void perform(AdvancedData data) {
         for(PlayerInfo pi : data.getTeam(this.scoring_side).player){
-            if (pi.penalty == Penalties.NONE) {
+            if (pi.penalty == Penalties.NONE && pi.redCardCount == 0) {
                 pi.dropInPoints += 1;
             }
         }

--- a/src/controller/action/ui/GameInterruption.java
+++ b/src/controller/action/ui/GameInterruption.java
@@ -16,8 +16,6 @@ import data.values.SecondaryGameStates;
  * - Penalty Kick
  * - Direct Free Kick
  * - Indirect Free Kick
- *
- * Soon to be introduced
  * - Corner Kick
  * - Goal Kick
  * - Throw-in

--- a/src/controller/action/ui/RetakeGameInterruption.java
+++ b/src/controller/action/ui/RetakeGameInterruption.java
@@ -1,0 +1,36 @@
+package controller.action.ui;
+
+import common.Log;
+import controller.action.ActionType;
+import controller.action.GCAction;
+import data.states.AdvancedData;
+
+public class RetakeGameInterruption  extends GCAction {
+    /**
+     * Which side has the advantage with this game interruption
+     */
+    private int side;
+
+    public RetakeGameInterruption(int side) {
+        super(ActionType.UI);
+        this.side = side;
+    }
+
+
+    @Override
+    public void perform(AdvancedData data)
+    {
+        data.secGameStateInfo.setFreeKickData(data.team[side].teamNumber, (byte) 0);
+        data.gameClock.clearSecondaryClock();
+
+        Log.setNextMessage("Retaking: " + data.secGameState.toString() + " " + data.team[side].teamColor.toString());
+    }
+
+    @Override
+    public boolean isLegal(AdvancedData data) {
+        byte[] bytes = data.secGameStateInfo.toByteArray();
+        byte team = bytes[0];
+        boolean isGoodTeam = team == data.team[side].teamNumber;
+        return data.secGameState.isGameInterruption() && isGoodTeam;
+    }
+}

--- a/src/controller/ui/localization/Localization.java
+++ b/src/controller/ui/localization/Localization.java
@@ -12,6 +12,8 @@ public class Localization {
     public final String GOAL_KICK = "Goal Kick";
     public final String THROW_IN = "Throw-In";
 
+    public final String RETAKE = "Retake";
+
     public final String COACH = "Coach";
     public final String EJECTED = "Ejected";
 

--- a/src/controller/ui/ui/components/HLTeamActions.java
+++ b/src/controller/ui/ui/components/HLTeamActions.java
@@ -25,6 +25,7 @@ public class HLTeamActions extends TeamActions {
     private GameInterruptionButton cornerKick;
     private GameInterruptionButton goalKick;
     private GameInterruptionButton throwIn;
+    private JButton retake;
 
     public HLTeamActions(Side side) {
         super(side);
@@ -47,8 +48,7 @@ public class HLTeamActions extends TeamActions {
         cornerKick = new GameInterruptionButton(LocalizationManager.getLocalization().CORNER_KICK);
         goalKick = new GameInterruptionButton(LocalizationManager.getLocalization().GOAL_KICK);
         throwIn = new GameInterruptionButton(LocalizationManager.getLocalization().THROW_IN);
-
-        System.out.println("Adding action listeners");
+        retake = new GameInterruptionButton(LocalizationManager.getLocalization().RETAKE);
 
         directFreeKick.addActionListener(new DirectFreeKick(side.value()));
         indirectFreeKick.addActionListener(new IndirectFreeKick(side.value()));
@@ -56,10 +56,9 @@ public class HLTeamActions extends TeamActions {
         cornerKick.addActionListener(new CornerKick(side.value()));
         goalKick.addActionListener(new GoalKick(side.value()));
         throwIn.addActionListener(new ThrowIn(side.value()));
+        retake.addActionListener(new RetakeGameInterruption(side.value()));
 
-        System.out.println("Adding action listeners");
-
-        int nb_rows = 7;
+        int nb_rows = 8;
         int row = 0;
         double row_height = 1.0 / nb_rows;
         layout.add(0, 0, 1, row_height, timeOut); row++;
@@ -69,6 +68,7 @@ public class HLTeamActions extends TeamActions {
         layout.add(0, row * row_height, 1, row_height, cornerKick);row++;
         layout.add(0, row * row_height, 1, row_height, goalKick);row++;
         layout.add(0, row * row_height, 1, row_height, throwIn);row++;
+        layout.add(0, row * row_height, 1, row_height, retake);row++;
 
         timeOut.setVisible(true);
 
@@ -89,6 +89,9 @@ public class HLTeamActions extends TeamActions {
         update(data, cornerKick, new CornerKick(side.value()));
         update(data, goalKick, new GoalKick(side.value()));
         update(data, throwIn, new ThrowIn(side.value()));
+
+        boolean isRetakeAllowed = new RetakeGameInterruption(side.value()).isLegal(data);
+        retake.setEnabled(isRetakeAllowed);
     }
 
     private void update(AdvancedData data, GameInterruptionButton button, GameInterruption action) {

--- a/src/controller/ui/ui/components/HLTeamActions.java
+++ b/src/controller/ui/ui/components/HLTeamActions.java
@@ -7,6 +7,7 @@ import controller.ui.localization.LocalizationManager;
 import controller.ui.ui.customized.Button;
 import controller.ui.ui.customized.GameInterruptionButton;
 import controller.ui.ui.customized.JMultiStepIndicatorButton;
+import controller.ui.ui.customized.RetakeButton;
 import data.states.AdvancedData;
 import data.values.SecondaryGameStates;
 import data.values.Side;
@@ -25,7 +26,7 @@ public class HLTeamActions extends TeamActions {
     private GameInterruptionButton cornerKick;
     private GameInterruptionButton goalKick;
     private GameInterruptionButton throwIn;
-    private JButton retake;
+    private RetakeButton retake;
 
     public HLTeamActions(Side side) {
         super(side);
@@ -48,7 +49,7 @@ public class HLTeamActions extends TeamActions {
         cornerKick = new GameInterruptionButton(LocalizationManager.getLocalization().CORNER_KICK);
         goalKick = new GameInterruptionButton(LocalizationManager.getLocalization().GOAL_KICK);
         throwIn = new GameInterruptionButton(LocalizationManager.getLocalization().THROW_IN);
-        retake = new GameInterruptionButton(LocalizationManager.getLocalization().RETAKE);
+        retake = new RetakeButton(LocalizationManager.getLocalization().RETAKE);
 
         directFreeKick.addActionListener(new DirectFreeKick(side.value()));
         indirectFreeKick.addActionListener(new IndirectFreeKick(side.value()));

--- a/src/controller/ui/ui/components/Robot.java
+++ b/src/controller/ui/ui/components/Robot.java
@@ -35,6 +35,7 @@ public class Robot extends AbstractComponent {
     Button robot;
     protected JLabel robotLabel;
 
+    protected JButton warningCard;
     protected JButton yellowCard;
     protected JButton redCard;
 
@@ -90,10 +91,11 @@ public class Robot extends AbstractComponent {
         double rightOffset = 0.01;
 
         double cardWidth = 0.4 / aspectRatio;
-        robotLayout.add(1 - cardWidth - rightOffset, 0.1, cardWidth, 0.75, yellowCard);
-        robotLayout.add(1 - 2 * cardWidth - rightOffset, 0.1, cardWidth, 0.75, redCard);
+        robotLayout.add(1 - cardWidth - rightOffset, 0.1, cardWidth, 0.75, warningCard);
+        robotLayout.add(1 - 2 * cardWidth - rightOffset, 0.1, cardWidth, 0.75, yellowCard);
+        robotLayout.add(1 - 3 * cardWidth - rightOffset, 0.1, cardWidth, 0.75, redCard);
 
-        robotLayout.add(1 - 4 * cardWidth - rightOffset, 0.1, cardWidth*2, 0.75, makeGoalie);
+        robotLayout.add(1 - 5 * cardWidth - rightOffset, 0.1, cardWidth*2, 0.75, makeGoalie);
 
         double restWidth = 1 - 2 * cardWidth - rightOffset;
 
@@ -124,6 +126,10 @@ public class Robot extends AbstractComponent {
         robotLabel.setHorizontalAlignment(JLabel.LEFT);
         robotLabel.setIcon(lanIcon);
         robotLabel.setBorder(new EmptyBorder(10, 10, 10, 10));
+
+
+        warningCard = new Button("Warning");
+        warningCard.addActionListener(new CardIncrease(side, this.id, Color.BLUE));
 
         yellowCard = new Button("Yellow");
         yellowCard.addActionListener(new CardIncrease(side, this.id, Color.YELLOW));
@@ -232,6 +238,10 @@ public class Robot extends AbstractComponent {
     }
 
     private void updatePenaltyCards(PlayerInfo playerInfo) {
+        warningCard.setText(String.valueOf(playerInfo.warningCardCount));
+        warningCard.setMargin(new Insets(0, 0, 0, 0));
+        warningCard.setFont(FontHelper.boldStandardFont());
+
         yellowCard.setText(String.valueOf(playerInfo.yellowCardCount));
         yellowCard.setMargin(new Insets(0, 0, 0, 0));
         yellowCard.setFont(FontHelper.boldStandardFont());
@@ -239,6 +249,12 @@ public class Robot extends AbstractComponent {
         redCard.setText(String.valueOf(playerInfo.redCardCount));
         redCard.setMargin(new Insets(0, 0, 0, 0));
         redCard.setFont(FontHelper.boldStandardFont());
+
+        if (playerInfo.warningCardCount > 0) {
+            warningCard.setBackground(new Color(0, 100, 255));
+        } else {
+            warningCard.setBackground(new Color(50, 180, 255));
+        }
 
         if (playerInfo.yellowCardCount > 0) {
             yellowCard.setBackground(new Color(255, 255, 0));

--- a/src/controller/ui/ui/components/Robot.java
+++ b/src/controller/ui/ui/components/Robot.java
@@ -183,9 +183,11 @@ public class Robot extends AbstractComponent {
         // Update the goalie info
         updateGoalieMarker(robotInfo);
 
-        if (robotInfo.penalty != Penalties.NONE && data.getRemainingPenaltyTime(sideValue, robotId) > 0) {
-            if (!data.ejected[sideValue][robotId]) {
-                int seconds = data.getRemainingPenaltyTime(sideValue, robotId);
+        int seconds = data.getRemainingPenaltyTime(sideValue, robotId);
+        boolean isEjected = data.ejected[sideValue][robotId];
+        if (robotInfo.penalty != Penalties.NONE &&
+                (seconds > 0 || robotInfo.penalty == Penalties.SUBSTITUTE || isEjected)) {
+            if (!isEjected) {
                 boolean servingPenalty = data.isServingPenalty[sideValue][robotId];
                 boolean pickup = Rules.league instanceof HL && robotInfo.penalty == Penalties.HL_PICKUP_OR_INCAPABLE;
 

--- a/src/controller/ui/ui/components/RobotWithDropInCounter.java
+++ b/src/controller/ui/ui/components/RobotWithDropInCounter.java
@@ -33,8 +33,9 @@ public class RobotWithDropInCounter extends Robot {
 
         robotLayout.add(1 - rightOffset + 0.02, 0.1, 0.18, 0.75, diss);
 
-        robotLayout.add(1 - cardWidth - rightOffset, 0.1, cardWidth, 0.75, yellowCard);
-        robotLayout.add(1 - 2 * cardWidth - rightOffset, 0.1, cardWidth, 0.75, redCard);
+        robotLayout.add(1 - cardWidth - rightOffset, 0.1, cardWidth, 0.75, warningCard);
+        robotLayout.add(1 - 2 *cardWidth - rightOffset, 0.1, cardWidth, 0.75, yellowCard);
+        robotLayout.add(1 - 3 * cardWidth - rightOffset, 0.1, cardWidth, 0.75, redCard);
 
         double restWidth = 1 - 2 * cardWidth - rightOffset;
 

--- a/src/controller/ui/ui/customized/GameInterruptionButton.java
+++ b/src/controller/ui/ui/customized/GameInterruptionButton.java
@@ -8,8 +8,6 @@ package controller.ui.ui.customized;
  * - Penalty Kick
  * - Direct Free Kick
  * - Indirect Free Kick
- *
- * Soon to be introduced
  * - Corner Kick
  * - Goal Kick
  * - Throw-in

--- a/src/controller/ui/ui/customized/RetakeButton.java
+++ b/src/controller/ui/ui/customized/RetakeButton.java
@@ -1,0 +1,11 @@
+package controller.ui.ui.customized;
+/**
+ * @author Ludovic Hofer
+ *
+ * This class allows to represents the button that restarts GameInterruptions
+ */
+public class RetakeButton extends Button {
+    public RetakeButton(String caption){
+        super(caption);
+    }
+}

--- a/src/data/PlayerInfo.java
+++ b/src/data/PlayerInfo.java
@@ -28,8 +28,9 @@ public class PlayerInfo implements Serializable
     //this is streamed
     public Penalties penalty = Penalties.NONE; // penalty state of the player
     public byte secsTillUnpenalised;    // estimate of time till unpenalised
-    public byte yellowCardCount = 0;    // estimate of time till unpenalised
-    public byte redCardCount = 0;    // estimate of time till unpenalised
+    public byte warningCardCount = 0; // Number of warnings received by the robot (not serialized)
+    public byte yellowCardCount = 0;    // Number of yellow cards received by the robot
+    public byte redCardCount = 0;    // Number of red cards received by the robot
     public byte isGoalie = 0;    // Save the information whether they are the goalie here to make it easier for the ux
 
     public byte dropInPoints = 0; // Number of drop in points


### PR DESCRIPTION
The following elements are present:

- Fix of a bug introduced sooner with respect to display of substitute on robot buttons
- Keeping track of warnings per robot + forbidding to give more cards once a robot has a red card
- For Drop-Ins: robots with red-cards do not receive points anymore
- Adding Retake button working for all game interruptions