### PR TITLE
Missing STATE_CORNERKICK in gamestate.py

### DIFF
--- a/protocols/python/gamestate.py
+++ b/protocols/python/gamestate.py
@@ -71,6 +71,7 @@ GameState = "gamedata" / Struct(
                              STATE_DIRECT_FREEKICK=4,
                              STATE_INDIRECT_FREEKICK=5,
                              STATE_PENALTYKICK=6,
+                             STATE_CORNERKICK=7,
                              DROPBALL=128,
                              UNKNOWN=255
                              ),


### PR DESCRIPTION
Although the value (7) is correctly sent by the GameController, it was not defined in gamestate.py.