### PR TITLE
Additional features and fixes required for the full implementation of the AutoReferee

### DIFF
--- a/protocols/python/gamestate.py
+++ b/protocols/python/gamestate.py
@@ -18,7 +18,8 @@ RobotInfo = "robot_info" / Struct(
     "penalty" / Byte,
     "secs_till_unpenalized" / Byte,
     "number_of_yellow_cards" / Byte,
-    "number_of_red_cards" / Byte
+    "number_of_red_cards" / Byte,
+    "goalkeeper" / Flag
 )
 
 TeamInfo = "team" / Struct(

--- a/protocols/python/receiver.py
+++ b/protocols/python/receiver.py
@@ -47,7 +47,8 @@ class GameStateReceiver(object):
         # Information that is used when sending the answer to the game controller
         self.team = team
         self.player = player
-        self.man_penalize = False
+        self.man_penalize = True
+        self.is_goalkeeper = True
 
         # The address listening on and the port for sending back the robots meta data
         self.addr = addr
@@ -114,6 +115,8 @@ class GameStateReceiver(object):
     def answer_to_gamecontroller(self, peer):
         """ Sends a life sign to the game controller """
         return_message = 0 if self.man_penalize else 2
+        if self.is_goalkeeper:
+            return_message = 3
 
         data = Container(
             header=b"RGrt",

--- a/src/controller/Clock.java
+++ b/src/controller/Clock.java
@@ -15,7 +15,7 @@ public class Clock
      * it fires after this time, it will allways take some more millis depending
      * on the performance.
      */
-    public static final int HEARTBEAT = 500; // 2Hz
+    public static int HEARTBEAT = 500; // 2Hz
 
     /** The instance of the singleton. */
     private static Clock instance;

--- a/src/controller/GameControllerSimulator.java
+++ b/src/controller/GameControllerSimulator.java
@@ -57,9 +57,10 @@ public class GameControllerSimulator {
      */
     private final static String LOG_DIRECTORY = "logs";
 
-    private static final String HELP_TEMPLATE = "Usage: java -jar GameController.jar {options}"
+    private static final String HELP_TEMPLATE = "Usage: java -jar GameControllerSimulator.jar {options}"
             + "\n  (-h | --help)                   display help"
             + "\n  (-t | --test)                   use test-mode - currently only disabling the delayed switch to playing in SPL"
+            + "\n  (-f | --fast)                   use fast mode for running the GameController faster than real time"
             + "\n  (-i | --interface) <interface>  set network interface (default is a connected IPv4 interface)"
             + "\n  (-l | --league) %s%sselect league (default is spl)"
             + "\n  (-w | --window)                 select window mode (default is fullscreen)"
@@ -78,6 +79,8 @@ public class GameControllerSimulator {
     private static final String COMMAND_PORT_SHORT = "-p";
     private static final String COMMAND_CONFIG= "--config";
     private static final String COMMAND_CONFIG_SHORT = "-c";
+    private static final String COMMAND_FAST= "--fast";
+    private static final String COMMAND_FAST_SHORT = "-f";
 
     /** Dynamically settable path to the config root folder */
     private static final String CONFIG_ROOT = System.getProperty("CONFIG_ROOT", "");
@@ -101,6 +104,7 @@ public class GameControllerSimulator {
         String interfaceName = "";
         boolean windowMode = false;
         boolean testMode = false;
+        boolean fastMode = false;
 
         parsing:
         for (int i = 0; i < args.length; i++) {
@@ -130,6 +134,9 @@ public class GameControllerSimulator {
                 continue parsing;
             } else if (args[i].equals(COMMAND_CONFIG_SHORT) || args[i].equals(COMMAND_CONFIG)) {
                 CONFIG = args[++i];
+                continue parsing;
+            } else if (args[i].equals(COMMAND_FAST_SHORT) || args[i].equals(COMMAND_FAST)) {
+                fastMode = true;
                 continue parsing;
             }
             String leagues = "";
@@ -321,6 +328,9 @@ public class GameControllerSimulator {
             Sender sender = Sender.getInstance();
             sender.send(data);
             sender.start();
+            if (fastMode) {
+                sender.UPDATEFREQUENCY = 50; //set the message update frequency to 50ms
+            }
 
             //event-handler
             EventHandler.getInstance().data = data;
@@ -376,6 +386,10 @@ public class GameControllerSimulator {
         gui.update(data);
 
 
+
+        if (fastMode) {
+            Clock.HEARTBEAT = 5; //set the clock update to 5ms
+        }
         //clock runs until window is closed
         Clock.getInstance().start();
 

--- a/src/controller/action/ui/KickOff.java
+++ b/src/controller/action/ui/KickOff.java
@@ -65,9 +65,11 @@ public class KickOff extends GCAction
     {
         return (data.kickOffTeam == data.team[side].teamNumber)
                 || ((Rules.league.kickoffChoice)
-                    && (data.secGameState == SecondaryGameStates.NORMAL)
-                    && (data.firstHalf == GameControlData.C_TRUE)
-                    && (data.gameState == GameStates.INITIAL))
+                    && (((data.secGameState == SecondaryGameStates.NORMAL)
+                        && (data.firstHalf == GameControlData.C_TRUE)
+                        && (data.gameState == GameStates.INITIAL))
+                    || ((data.secGameState == SecondaryGameStates.PENALTYSHOOT)
+                        && (data.gameState == GameStates.INITIAL))))
                 || data.testmode;
     }
 }

--- a/src/controller/action/ui/half/FirstHalfOvertime.java
+++ b/src/controller/action/ui/half/FirstHalfOvertime.java
@@ -64,7 +64,10 @@ public class FirstHalfOvertime extends GCAction {
                 && (data.gameState == GameStates.FINISHED)
                 && (data.firstHalf != GameControlData.C_TRUE)
                 && (data.team[0].score == data.team[1].score)
-                && (data.team[0].score > 0)) {
+                && ((data.team[0].score > 0) ||
+                    Rules.league.getClass().getSimpleName().equals("HLSimulationKid") ||
+                    Rules.league.getClass().getSimpleName().equals("HLSimulationAdult"))) //Score > 0 is not required for over time according to the HL Rule book
+        {
             return true;
         }
 

--- a/src/controller/net/RobotWatcher.java
+++ b/src/controller/net/RobotWatcher.java
@@ -3,10 +3,12 @@ package controller.net;
 import controller.EventHandler;
 import controller.SystemClock;
 import controller.action.ActionBoard;
+import controller.action.ui.MakeGoalieAction;
 import data.communication.GameControlReturnData;
 import data.Rules;
 import data.values.Penalties;
 import data.values.PlayerResponses;
+import data.values.Side;
 
 /**
  * @author Marcel Steinbeck, Michel Bartsch
@@ -77,6 +79,11 @@ public class RobotWatcher
             } else if ((gameControlReturnData.message == PlayerResponses.MAN_UNPENALISE)
                     && (EventHandler.getInstance().data.team[team].player[number-1].penalty != Penalties.NONE)) {
                 ActionBoard.manualUnpen[team][number-1].actionPerformed(null);
+            } else if (gameControlReturnData.message == PlayerResponses.GOALKEEPER) {
+                MakeGoalieAction makeGoalie = new MakeGoalieAction(Side.getFromInt(team), number-1);
+                if(makeGoalie.isLegal(EventHandler.getInstance().data)) {
+                    makeGoalie.perform(EventHandler.getInstance().data);
+                }
             }
         }
     }

--- a/src/controller/net/Sender.java
+++ b/src/controller/net/Sender.java
@@ -51,6 +51,11 @@ public class Sender extends Thread {
     private AdvancedData data;
 
     /**
+     *
+     */
+    public static int UPDATEFREQUENCY = 500;
+
+    /**
      * Creates a new Sender.
      *
      * @throws SocketException if an error occurs while creating the socket
@@ -157,7 +162,7 @@ public class Sender extends Thread {
             }
 
             try {
-                Thread.sleep(500);
+                Thread.sleep(UPDATEFREQUENCY);
             } catch (InterruptedException e) {
                 interrupt();
             }

--- a/src/data/PlayerInfo.java
+++ b/src/data/PlayerInfo.java
@@ -23,7 +23,8 @@ public class PlayerInfo implements Serializable
             1 + // penalty
             1 +  // secsToUnpen
             1 + // Numbers of yellow cards
-            1; // Numbers of red cards
+            1 + // Numbers of red cards
+            1; // Whether the robot is the current GoalKeeper
 
     //this is streamed
     public Penalties penalty = Penalties.NONE; // penalty state of the player
@@ -47,6 +48,7 @@ public class PlayerInfo implements Serializable
         buffer.put(secsTillUnpenalised);
         buffer.put(yellowCardCount);
         buffer.put(redCardCount);
+        buffer.put(isGoalie);
         return buffer.array();
     }
 
@@ -63,6 +65,7 @@ public class PlayerInfo implements Serializable
         secsTillUnpenalised = buffer.get();
         yellowCardCount = buffer.get();
         redCardCount = buffer.get();
+        isGoalie = buffer.get();
     }
 
     @Override
@@ -73,6 +76,7 @@ public class PlayerInfo implements Serializable
         out += "secsTillUnpenalised: "+secsTillUnpenalised+"\n";
         out += "yellowCardCount: "+yellowCardCount+"\n";
         out += "redCardCount: "+redCardCount+"\n";
+        out += "isGoalie: "+isGoalie+"\n";
         return out;
     }
 }

--- a/src/data/values/PlayerResponses.java
+++ b/src/data/values/PlayerResponses.java
@@ -9,6 +9,7 @@ public enum PlayerResponses implements DocumentingMarkdown {
     MAN_PENALISE(0, "Manual Penalized"),
     MAN_UNPENALISE(1, "Manual Unpenalized"),
     ALIVE(2, "Alive"),
+    GOALKEEPER(3, "Goalkeeper"),
 
     UNKNOWN(255, "Unknown");
 


### PR DESCRIPTION
Additional updates required for the advanced AutoReferee.
- GameController can now be started with a --fast mode to set the Clock HEARTBEAT to 5ms and the Sender UPDATEFREQUENCY to 50ms (#134)
- Teams can now send a UDP response of type 3 to indicate that the player sending the message is goalkeeper. The PlayerInfo (sent as part of the UDP GameState message) now includes a Flag whether a current player is the goalkeeper (#113)
- In the HLSimulatedKid and HLSimulatedAdult rules it is not possible to switch to overtime without requiring any goals to be scored in the game (#126)
- Made it legal to change kick-off in the beginning of the penalty shoot-out (#136)