### PR TITLE
Enhancements and fixes for the AutoReferee development

### DIFF
--- a/protocols/python/receiver.py
+++ b/protocols/python/receiver.py
@@ -17,6 +17,8 @@ interface with the GC can utilize the new protocol.
 import socket
 import time
 import logging
+import argparse
+import sys
 
 # Requires construct==2.5.3
 from construct import Container, ConstError
@@ -33,6 +35,11 @@ DEFAULT_LISTENING_HOST = '0.0.0.0'
 GAME_CONTROLLER_LISTEN_PORT = 3838
 GAME_CONTROLLER_ANSWER_PORT = 3939
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--team', type=int, default=1, help="team ID, default is 1")
+parser.add_argument('--player', type=int, default=1, help="player ID, default is 1")
+parser.add_argument('--goalkeeper', action="store_true", help="if this flag is present, the player takes the role of the goalkeeper")
+
 
 class GameStateReceiver(object):
     """ This class puts up a simple UDP Server which receives the
@@ -43,12 +50,12 @@ class GameStateReceiver(object):
 
     After this we send a package back to the GC """
 
-    def __init__(self, team, player, addr=(DEFAULT_LISTENING_HOST, GAME_CONTROLLER_LISTEN_PORT), answer_port=GAME_CONTROLLER_ANSWER_PORT):
+    def __init__(self, team, player, is_goalkeeper, addr=(DEFAULT_LISTENING_HOST, GAME_CONTROLLER_LISTEN_PORT), answer_port=GAME_CONTROLLER_ANSWER_PORT):
         # Information that is used when sending the answer to the game controller
         self.team = team
         self.player = player
         self.man_penalize = True
-        self.is_goalkeeper = True
+        self.is_goalkeeper = is_goalkeeper
 
         # The address listening on and the port for sending back the robots meta data
         self.addr = addr
@@ -153,10 +160,11 @@ class GameStateReceiver(object):
 class SampleGameStateReceiver(GameStateReceiver):
 
     def on_new_gamestate(self, state):
-        print(state)
-        print(state.secondary_state_info)
+       print(state)
+       print(state.secondary_state_info)
 
 if __name__ == '__main__':
-    rec = SampleGameStateReceiver(team=1, player=1)
+    args = parser.parse_args(sys.argv[1:])
+    rec = SampleGameStateReceiver(team=args.team, player=args.player, is_goalkeeper=args.goalkeeper)
     rec.receive_forever()
 

--- a/src/controller/GameControllerSimulator.java
+++ b/src/controller/GameControllerSimulator.java
@@ -3,6 +3,7 @@ package controller;
 import common.ApplicationLock;
 import common.Log;
 import controller.action.ActionBoard;
+import controller.action.ui.MakeGoalieAction;
 import controller.net.GameControlReturnDataReceiver;
 import controller.net.SPLCoachMessageReceiver;
 import controller.net.Sender;
@@ -19,6 +20,7 @@ import data.states.AdvancedData;
 import data.states.GamePreparationData;
 import data.teams.TeamLoadInfo;
 import data.values.GameTypes;
+import data.values.Side;
 import org.json.simple.*;
 import org.json.simple.parser.JSONParser;
 
@@ -319,6 +321,11 @@ public class GameControllerSimulator {
         if (testMode) {
             Rules.league.delayedSwitchToPlaying = 0;
         }
+
+        MakeGoalieAction makeGoalieLeft = new MakeGoalieAction(Side.getFromInt(0),0);
+        makeGoalieLeft.perform(data);
+        MakeGoalieAction makeGoalieRight = new MakeGoalieAction(Side.getFromInt(1),0);
+        makeGoalieRight.perform(data);
 
         SystemClock.setSimulatedTime();
 

--- a/src/controller/action/ui/GameInterruption.java
+++ b/src/controller/action/ui/GameInterruption.java
@@ -88,12 +88,18 @@ public class GameInterruption extends GCAction {
     public boolean isLegal(AdvancedData data)
     {
         if (data.testmode) return true;
-        if (isActive(data)) return true;
+        if (isActive(data) && data.secGameStateInfo.toByteArray()[1] != 1) return true;
         boolean validGameState = data.gameState == GameStates.PLAYING;
         boolean validSecGameState = data.secGameState == SecondaryGameStates.NORMAL
-                    || data.secGameState == SecondaryGameStates.OVERTIME;
+                    || data.secGameState == SecondaryGameStates.OVERTIME
+                    || isActive(data);
+        boolean validTimingOfReady = (data.secGameStateInfo.toByteArray()[1] == 1 //current sub mode is preparation phase
+                    && data.getSecondaryTime (3) != null //a secondary game clock exists
+                    && data.getSecondaryTime(3) < (Rules.league.game_interruption_preparation_time - Rules.league.game_interruption_minimal_ready_time)) //the minimal time guaranteed to the opponent has passed
+                    || !data.secGameState.isGameInterruption() // if there is no game interruption the action is legal
+                    || (data.secGameStateInfo.toByteArray()[1] != 1); //in any other sub mode the action is legal
 
-        return validGameState && validSecGameState;
+        return validGameState && validSecGameState && validTimingOfReady;
     }
 
     public SecondaryGameStates getSecGameState() {

--- a/src/controller/action/ui/GameInterruption.java
+++ b/src/controller/action/ui/GameInterruption.java
@@ -77,7 +77,7 @@ public class GameInterruption extends GCAction {
                     data.previousSecGameState = secGameState;
                     data.secGameStateInfo.reset();
                     Log.setNextMessage("End " + secGameState.toString() + data.team[side].teamColor.toString());
-                    data.gameClock.addExtraClock(secGameState.toString(), 10);
+                    data.whenCurrentSecondaryGameStateEnded = data.getTime();
                     ActionBoard.clockPause.perform(data);
                     break;
             }

--- a/src/controller/net/RobotWatcher.java
+++ b/src/controller/net/RobotWatcher.java
@@ -8,6 +8,7 @@ import data.communication.GameControlReturnData;
 import data.Rules;
 import data.values.Penalties;
 import data.values.PlayerResponses;
+import data.values.SecondaryGameStates;
 import data.values.Side;
 
 /**
@@ -79,12 +80,34 @@ public class RobotWatcher
             } else if ((gameControlReturnData.message == PlayerResponses.MAN_UNPENALISE)
                     && (EventHandler.getInstance().data.team[team].player[number-1].penalty != Penalties.NONE)) {
                 ActionBoard.manualUnpen[team][number-1].actionPerformed(null);
-            } else if (gameControlReturnData.message == PlayerResponses.GOALKEEPER) {
+            }} else if (gameControlReturnData.message == PlayerResponses.GOALKEEPER) {
                 MakeGoalieAction makeGoalie = new MakeGoalieAction(Side.getFromInt(team), number-1);
-                if(makeGoalie.isLegal(EventHandler.getInstance().data)) {
-                    makeGoalie.perform(EventHandler.getInstance().data);
+                    if(makeGoalie.isLegal(EventHandler.getInstance().data)) {
+                        makeGoalie.perform(EventHandler.getInstance().data);
+                    }
+            }  else if (gameControlReturnData.message == PlayerResponses.GAME_INTERRUPTION_READY) {
+                if (EventHandler.getInstance().data.secGameStateInfo.toByteArray()[1] == 1 // we are currently in the preparation phase
+                        && EventHandler.getInstance().data.secGameStateInfo.toByteArray()[0] == gameControlReturnData.team) { // the robot is from the team begin allowed to execute the game interruption
+                    if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.DIRECT_FREEKICK
+                            && ActionBoard.directFreeKick[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.directFreeKick[team].perform(EventHandler.getInstance().data);
+                    } else if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.INDIRECT_FREEKICK
+                            && ActionBoard.indirectFreeKick[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.indirectFreeKick[team].perform(EventHandler.getInstance().data);
+                    } else if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.CORNER_KICK
+                            && ActionBoard.cornerKick[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.cornerKick[team].perform(EventHandler.getInstance().data);
+                    } else if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.GOAL_KICK
+                            && ActionBoard.goalKick[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.goalKick[team].perform(EventHandler.getInstance().data);
+                    } else if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.THROW_IN
+                            && ActionBoard.throwIn[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.throwIn[team].perform(EventHandler.getInstance().data);
+                    } else if (EventHandler.getInstance().data.secGameState == SecondaryGameStates.PENALTYKICK
+                            && ActionBoard.penaltyKick[team].isLegal(EventHandler.getInstance().data)) {
+                        ActionBoard.penaltyKick[team].perform(EventHandler.getInstance().data);
+                    }
                 }
-            }
         }
     }
 

--- a/src/controller/ui/ui/components/SimulatorUpdateComponent.java
+++ b/src/controller/ui/ui/components/SimulatorUpdateComponent.java
@@ -328,7 +328,8 @@ public class SimulatorUpdateComponent extends AbstractComponent{
             case "PLAY":
                 if(ActionBoard.play.isLegal(data)) {
                     ActionBoard.play.actionPerformed(null);
-                    releaseAllPenalties(data);
+                    data.resetPenaltyTimes();
+                    data.resetPenalties();
                     actionAccepted(values[0]);
                 }
                 else { actionRejected(values[0]); }
@@ -372,23 +373,6 @@ public class SimulatorUpdateComponent extends AbstractComponent{
                 actionRejected(values[0]);
                 break;
         }
-    }
-
-    /**
-     * This function releases all penalties from all players
-     * (To be called when game state switches to PLAY)
-     * @param data
-     */
-    private void releaseAllPenalties(AdvancedData data) {
-        for (int side = 0; side <= 1; side++) {
-            for (int robot = 0; robot < Rules.league.teamSize; robot++) {
-                if (data.isServingPenalty[side][robot]) {
-                    data.team[side].player[robot].penalty = Penalties.NONE;
-                    data.isServingPenalty[side][robot] = false;
-                }
-            }
-        }
-
     }
 
     private void actionAccepted(String id) {

--- a/src/data/Rules.java
+++ b/src/data/Rules.java
@@ -123,4 +123,7 @@ public abstract class Rules
 
     /** The time a team has to prepare for the penalty kick **/
     public int penalty_kick_preparation_time;
+
+    /** The time an opponent is guaranteed to move away from the ball in preparation phase **/
+    public int game_interruption_minimal_ready_time;
 }

--- a/src/data/Rules.java
+++ b/src/data/Rules.java
@@ -58,6 +58,8 @@ public abstract class Rules
     public boolean kickoffChoice;
     /** Time in seconds the ball is blocked after kickoff. */
     public int kickoffTime;
+    /** Time in seconds the ball is blocked after a game interruption was executed. */
+    public int blockedAfterGameInterruption;
     /** Time in seconds before a global game stuck can be called. */
     public int minDurationBeforeStuck;
     /** The number of seconds switching to Playing is delayed. */

--- a/src/data/hl/HL.java
+++ b/src/data/hl/HL.java
@@ -111,5 +111,8 @@ public class HL extends Rules
 
         /** The time a team has to prepare for the penalty kick **/
         penalty_kick_preparation_time = 30;
+
+        /** The time an opponent is guaranteed to move away from the ball in preparation phase **/
+        game_interruption_minimal_ready_time = 15;
     }
 }

--- a/src/data/hl/HLSim.java
+++ b/src/data/hl/HLSim.java
@@ -113,5 +113,8 @@ public class HLSim extends Rules
 
         /** The time a team has to prepare for the penalty kick **/
         penalty_kick_preparation_time = 30;
+
+        /** The time an opponent is guaranteed to move away from the ball in preparation phase **/
+        game_interruption_minimal_ready_time = 15;
     }
 }

--- a/src/data/hl/HLSim.java
+++ b/src/data/hl/HLSim.java
@@ -40,6 +40,8 @@ public class HLSim extends Rules
         kickoffChoice = true;
         /** Time in seconds the ball is blocked after kickoff. */
         kickoffTime = 10;
+        /** Time in seconds the ball is blocked after a game interruption was executed. */
+        blockedAfterGameInterruption = 10;
         /** Time in seconds before a global game stuck can be called. */
         minDurationBeforeStuck = 2*60;
         /** The number of seconds switching to Playing is delayed. */

--- a/src/data/states/AdvancedData.java
+++ b/src/data/states/AdvancedData.java
@@ -45,6 +45,9 @@ public class AdvancedData extends GameControlData implements Cloneable
     
     /** When was switched to the current state? (ms) */
     public long whenCurrentGameStateBegan;
+
+    /** When was switched to the secondary game state? (ms) */
+    public long whenCurrentSecondaryGameStateEnded;
     
     /** How long ago started the current game state? (ms) Only set when written to log! */
     public long timeSinceCurrentGameStateBegan;
@@ -421,6 +424,7 @@ public class AdvancedData extends GameControlData implements Cloneable
             return null;
         }
         int timeKickOffBlocked = getRemainingSeconds(whenCurrentGameStateBegan, Rules.league.kickoffTime);
+        int timeFreeKickBlocked = getRemainingSeconds(whenCurrentSecondaryGameStateEnded, Rules.league.blockedAfterGameInterruption);
         if (kickOffTeam == DROPBALL) {
             timeKickOffBlocked = 0;
         }
@@ -436,6 +440,12 @@ public class AdvancedData extends GameControlData implements Cloneable
                 && timeKickOffBlocked >= -timeKickOffBlockedOvertime) {
             if (timeKickOffBlocked > 0) {
                 return timeKickOffBlocked;
+            } else {
+                return null;
+            }
+        } else if (gameState == GameStates.PLAYING && timeFreeKickBlocked >= -timeKickOffBlockedOvertime) {
+            if (timeFreeKickBlocked > 0) {
+                return timeFreeKickBlocked;
             } else {
                 return null;
             }

--- a/src/data/values/PlayerResponses.java
+++ b/src/data/values/PlayerResponses.java
@@ -10,6 +10,7 @@ public enum PlayerResponses implements DocumentingMarkdown {
     MAN_UNPENALISE(1, "Manual Unpenalized"),
     ALIVE(2, "Alive"),
     GOALKEEPER(3, "Goalkeeper"),
+    GAME_INTERRUPTION_READY(4, "Ready to execute game interruption"),
 
     UNKNOWN(255, "Unknown");
 


### PR DESCRIPTION
This pull request addresses the following issues:
- Added command line options for easier use of the receiver.py script
- Robot 1 is not set as goal keeper by default for both teams (#139)
- Instead of using an extra clock, the secondary clock is used for keeping track when the ball can be touched by an opponent robot after a game interruption occurs. This resolves both #132 since secondary clocks are always sent via the GameState, as well as #124 since no extra clock is used anymore 
- Players can now declare themselves ready for executing a free kick by sending message 4 to the GameController (#135)