### PR TITLE
Fixes for the AutoReferee development

### DIFF
--- a/src/controller/action/ui/MakeGoalieAction.java
+++ b/src/controller/action/ui/MakeGoalieAction.java
@@ -4,6 +4,7 @@ import controller.action.ActionType;
 import controller.action.GCAction;
 import data.PlayerInfo;
 import data.states.AdvancedData;
+import data.values.GameStates;
 import data.values.Side;
 
 
@@ -31,6 +32,15 @@ public class MakeGoalieAction extends GCAction {
 
     @Override
     public boolean isLegal(AdvancedData data) {
-        return true;
+        //GoalKeeper can only be changed during a stoppage of the game
+        //A stoppage is defined as the game not being in play (INITIAL, READY, SET, FINISHED)
+        //or being in the procedure of a game interruption (free kick, corner kick, goal kick, throw in, penalty kick)
+        boolean in_legal_game_state = data.gameState == GameStates.INITIAL
+                || data.gameState == GameStates.READY
+                || data.gameState == GameStates.SET
+                || data.gameState == GameStates.FINISHED;
+        boolean in_game_interruption = data.gameState == GameStates.PLAYING
+                && data.secGameState.isGameInterruption();
+        return in_legal_game_state || in_game_interruption;
     }
 }


### PR DESCRIPTION
- Goal keeper can only be changed during a stoppage of the game (#138)
- Potential fix for #114 - there seems to be a race condition in the Sender thread, where the main thread is responsible for creating the deep copy of the GameState and the Sender thread is responsible not just for reading from it but also for updating the time before sending it. This was definitely a problem and in my local setup this resolved the problem. Needs confirmation, though.