### PR TITLE
Fix: PHYSICAL_CONTACT relates to HLPushing and not TeammatePushing

### DIFF
--- a/src/controller/action/ActionBoard.java
+++ b/src/controller/action/ActionBoard.java
@@ -54,6 +54,7 @@ public class ActionBoard {
     public static Finish finish;
     public static BallManipulation ballManipulation;
     public static PickUpHL pickUpHL;
+    public static HLPushing hlPushing;
     public static TeammatePushing teammatePushing;
     public static Substitute substitute;
     public static DropBall dropBall;
@@ -130,6 +131,7 @@ public class ActionBoard {
         ballManipulation = new BallManipulation();
 
         pickUpHL = new PickUpHL();
+        hlPushing = new HLPushing();
         teammatePushing = new TeammatePushing();
         substitute = new Substitute();
         dropBall = new DropBall();

--- a/src/controller/ui/ui/components/SimulatorUpdateComponent.java
+++ b/src/controller/ui/ui/components/SimulatorUpdateComponent.java
@@ -304,9 +304,9 @@ public class SimulatorUpdateComponent extends AbstractComponent{
                 else { actionRejected(values[0]); }
                 break;
             case "PHYSICAL_CONTACT":
-                if (ActionBoard.teammatePushing.isLegal(data)) {
+                if (ActionBoard.hlPushing.isLegal(data)) {
                     PlayerInfo pi = data.team[side].player[robot_number];
-                    ActionBoard.teammatePushing.performOn(data, pi, side, robot_number);
+                    ActionBoard.hlPushing.performOn(data, pi, side, robot_number);
                     data.isServingPenalty[side][robot_number] = true;
                     actionAccepted(values[0]);
                 }


### PR DESCRIPTION
Apparently, the `HLPushing` was not included in the `ActionBoard`, using the `TeammatePushing` for the simulator led to proper calls from the AutoRef classified as `Illegal`.