### PR TITLE
[FIX] send correct timings

### DIFF
--- a/src/controller/net/Sender.java
+++ b/src/controller/net/Sender.java
@@ -174,6 +174,7 @@ public class Sender extends Thread {
                         Log.error("Error while sending");
                         e.printStackTrace();
                     }
+                    data = null;
                 }
             } finally {
                 readLockData.unlock();


### PR DESCRIPTION
This fixes #160.

`Sender::run` sends the content of `data` in an endless loop.
A second thread has to call `Sender::send` to update `data`. In most
cases this happens more often than the loop being executed. In some rare
occasions this is not the case.
Since `Sender::run` is modifying `data` on each loop the values become
invalid, causing the whole function to send out wrong data.

This commit fixes this, by deleting `data` each time it is being send.