### PR TITLE
[Fix] for #160 

### DIFF
--- a/src/controller/net/Sender.java
+++ b/src/controller/net/Sender.java
@@ -158,7 +158,7 @@ public class Sender extends Thread {
     @Override
     public void run() {
         while (!isInterrupted()) {
-            readLockData.lock();
+            writeLockData.lock();
             try {
                 if (data != null) {
                     data.updateTimes();
@@ -176,7 +176,7 @@ public class Sender extends Thread {
                     }
                 }
             } finally {
-                readLockData.unlock();
+                writeLockData.unlock();
             }
 
             try {

--- a/src/data/states/AdvancedData.java
+++ b/src/data/states/AdvancedData.java
@@ -282,10 +282,10 @@ public class AdvancedData extends GameControlData implements Cloneable
     public int getRemainingGameTime(boolean real)
     {
         int regularNumberOfPenaltyShots = (gameType == GameTypes.PLAYOFF) ? Rules.league.numberOfPenaltyShotsLong : Rules.league.numberOfPenaltyShotsShort;
-        int duration = secGameState == SecondaryGameStates.TIMEOUT ? secsRemaining :
-                secGameState == SecondaryGameStates.NORMAL ? Rules.league.halfTime :
-                secGameState.isGameInterruption() ? secsRemaining
-                : secGameState == SecondaryGameStates.OVERTIME ? Rules.league.overtimeTime
+        int duration = //secGameState == SecondaryGameStates.TIMEOUT ? secsRemaining :
+                (secGameState == SecondaryGameStates.NORMAL || secGameState == SecondaryGameStates.TIMEOUT || secGameState.isGameInterruption())? Rules.league.halfTime :
+                //secGameState.isGameInterruption() ? secsRemaining :
+                secGameState == SecondaryGameStates.OVERTIME ? Rules.league.overtimeTime
                 : Math.max(team[0].penaltyShot, team[1].penaltyShot) > regularNumberOfPenaltyShots
                 ? Rules.league.penaltyShotTimeSuddenDeath
                 : Rules.league.penaltyShotTime;

--- a/src/data/states/AdvancedData.java
+++ b/src/data/states/AdvancedData.java
@@ -282,9 +282,8 @@ public class AdvancedData extends GameControlData implements Cloneable
     public int getRemainingGameTime(boolean real)
     {
         int regularNumberOfPenaltyShots = (gameType == GameTypes.PLAYOFF) ? Rules.league.numberOfPenaltyShotsLong : Rules.league.numberOfPenaltyShotsShort;
-        int duration = //secGameState == SecondaryGameStates.TIMEOUT ? secsRemaining :
+        int duration =
                 (secGameState == SecondaryGameStates.NORMAL || secGameState == SecondaryGameStates.TIMEOUT || secGameState.isGameInterruption())? Rules.league.halfTime :
-                //secGameState.isGameInterruption() ? secsRemaining :
                 secGameState == SecondaryGameStates.OVERTIME ? Rules.league.overtimeTime
                 : Math.max(team[0].penaltyShot, team[1].penaltyShot) > regularNumberOfPenaltyShots
                 ? Rules.league.penaltyShotTimeSuddenDeath


### PR DESCRIPTION
There were two problems in the code:
(1) During game interruptions, the secondary clock was sometimes jumping. This is fixed by making the readLock a writeLock (since that thread is actually writing the data object when it updates the time.
(2) During game interruptions, the main time was jumping between two states. This seems to be caused by a weird way of calculating the remaining game time. During game-interruptions, the game duration was not the half-time-length but the remaining game time, which, to me, doesn't make any sense. The same was done for timeouts, which again doesn't make any sense to me. This fixes the bug and as far as I can see it doesn't create any new weird behavior. 