### PR TITLE
Handle switch to second half in overtime, fixes kick-off attribution in second half

### DIFF
--- a/src/controller/action/clock/ClockTick.java
+++ b/src/controller/action/clock/ClockTick.java
@@ -8,6 +8,7 @@ import data.communication.GameControlData;
 import data.Rules;
 import data.values.GameStates;
 import data.values.GameTypes;
+import data.values.SecondaryGameStates;
 
 
 /**
@@ -40,8 +41,10 @@ public class ClockTick extends GCAction
         } else if (data.gameState == GameStates.FINISHED) {
             Integer remainingPauseTime = data.getRemainingPauseTime();
             if (remainingPauseTime != null) {
-                if (data.firstHalf == GameControlData.C_TRUE && remainingPauseTime <= Rules.league.pauseTime / 2) {
+                if (data.firstHalf == GameControlData.C_TRUE && remainingPauseTime <= Rules.league.pauseTime / 2 && data.secGameState == SecondaryGameStates.NORMAL) {
                     ActionBoard.secondHalf.perform(data);
+                } else if (data.firstHalf == GameControlData.C_TRUE && remainingPauseTime <= Rules.league.pauseOverTime / 2 && data.secGameState == SecondaryGameStates.OVERTIME) {
+                    ActionBoard.secondHalfOvertime.perform(data);
                 } else if (data.firstHalf != GameControlData.C_TRUE && remainingPauseTime <= Rules.league.pausePenaltyShootOutTime / 2) {
                     ActionBoard.penaltyShoot.perform(data);
                 }

--- a/src/controller/ui/ui/components/SimulatorUpdateComponent.java
+++ b/src/controller/ui/ui/components/SimulatorUpdateComponent.java
@@ -86,7 +86,6 @@ public class SimulatorUpdateComponent extends AbstractComponent{
                 }
                 if(ActionBoard.kickOff[side].isLegal(data)) {
                     ActionBoard.kickOff[side].perform(data);
-                    if(side == 1) { data.leftSideKickoff = true; }
                     actionAccepted(values[0]);
                 }
                 else { actionRejected(values[0]); }

--- a/src/data/Rules.java
+++ b/src/data/Rules.java
@@ -54,6 +54,8 @@ public abstract class Rules
     public int readyTime;
     /** Time in seconds between first and second half. */
     public int pauseTime;
+    /** Time in seconds between first and second overtime half. */
+    public int pauseOverTime;
     /** If left and right side may both have the first kickoff. */
     public boolean kickoffChoice;
     /** Time in seconds the ball is blocked after kickoff. */

--- a/src/data/hl/HL.java
+++ b/src/data/hl/HL.java
@@ -36,6 +36,8 @@ public class HL extends Rules
         readyTime = 45;
         /** Time in seconds between first and second half. */
         pauseTime = 5*60;
+        /** Time in seconds between first and second overtime half. */
+        pauseTime = 5*60;
         /** If left and right side may both have the first kickoff. */
         kickoffChoice = true;
         /** Time in seconds the ball is blocked after kickoff. */

--- a/src/data/hl/HLSim.java
+++ b/src/data/hl/HLSim.java
@@ -36,6 +36,8 @@ public class HLSim extends Rules
         readyTime = 45;
         /** Time in seconds between first and second half. */
         pauseTime = 0;
+        /** Time in seconds between first and second overtime half. */
+        pauseOverTime = 0;
         /** If left and right side may both have the first kickoff. */
         kickoffChoice = true;
         /** Time in seconds the ball is blocked after kickoff. */

--- a/src/data/states/AdvancedData.java
+++ b/src/data/states/AdvancedData.java
@@ -310,6 +310,10 @@ public class AdvancedData extends GameControlData implements Cloneable
                 && (gameState == GameStates.INITIAL && firstHalf != C_TRUE && !timeOutActive[0] && !timeOutActive[1]
                 || gameState == GameStates.FINISHED && firstHalf == C_TRUE)) {
             return getRemainingSeconds(whenCurrentGameStateBegan, Rules.league.pauseTime);
+        } else if (secGameState == SecondaryGameStates.OVERTIME
+            && (gameState == GameStates.INITIAL && firstHalf != C_TRUE && !timeOutActive[0] && !timeOutActive[1]
+            || gameState == GameStates.FINISHED && firstHalf == C_TRUE)) {
+            return getRemainingSeconds(whenCurrentGameStateBegan, Rules.league.pauseOverTime);
         } else if (Rules.league.pausePenaltyShootOutTime != 0 && (gameType == GameTypes.PLAYOFF) && team[0].score == team[1].score
                 && (gameState == GameStates.INITIAL && secGameState == SecondaryGameStates.PENALTYSHOOT && !timeOutActive[0] && !timeOutActive[1]
                 || gameState == GameStates.FINISHED && firstHalf != C_TRUE)) {


### PR DESCRIPTION
- Bug in #165 should be solved with this and the AutoRef should advance to the second half time in overtime automatically
- Fixes bug in the GC that lead to the wrong attribution of kick-off in the second half if the AutoRef decided to flip kick-off for the first half time