### PR TITLE
Re-introducing and fixing drop-in

### DIFF
--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -285,10 +285,7 @@ public class GameController {
 
         //ui
         ActionBoard.init();
-        Log.state(data, Teams.getNames(false)[data.team[0].teamNumber]
-                + " (" + data.team[0].teamColor
-                + ") vs " + Teams.getNames(false)[data.team[1].teamNumber]
-                + " (" + data.team[1].teamColor + ")");
+        Log.state(data, data.team[0].getName() + " (" + data.team[0].teamColor + ") vs " + data.team[1].getName() + " (" + data.team[1].teamColor + ")");
 
 
         boolean isSim = Rules.league.leagueDirectory.equals("hl_sim");

--- a/src/data/Rules.java
+++ b/src/data/Rules.java
@@ -16,10 +16,10 @@ public abstract class Rules
     /** Note all league´s rules here to have them available. */
     public static final Rules[] LEAGUES = {
         new HL(),
-        new HLTeen(),
         new HLAdult(),
         new HLSimulationKid(),
-        new HLSimulationAdult()
+        new HLSimulationAdult(),
+        new HLDropIn()
     };
 
     public boolean equals(Rules rules) {

--- a/src/data/hl/HLDropIn.java
+++ b/src/data/hl/HLDropIn.java
@@ -13,5 +13,7 @@ public class HLDropIn extends HL
         leagueDirectory = "hl_dropin";
         /** If true, the drop-in player competition is active */
         dropInPlayerMode = true;
+        /** Drop in */
+        leagueName = "HL Drop-in";
     }
 }


### PR DESCRIPTION
This re-introduces Drop-in games in the GameController menu and fixes some part of the code that assume that the team numbers are contiguous and starting at 0 (looks like calling `getName()` on the objects does the same without this bug)

![image](https://user-images.githubusercontent.com/367022/177201920-471618d8-1654-4d4a-9b22-e90174a5bcdc.png)
