### PR TITLE
[Fix] Changed HL.java to not to reset time after Ready state in Knock-Out games

### DIFF
--- a/src/data/hl/HL.java
+++ b/src/data/hl/HL.java
@@ -118,6 +118,6 @@ public class HL extends Rules
         game_interruption_minimal_ready_time = 15;
 
         /** In Playoffs, it can be enabled to make up for the READY and SET time by adding them to the game for each time the phase was entered**/
-        enableAddingTimeInCurrentStateForPlayoffs = true;
+        enableAddingTimeInCurrentStateForPlayoffs = false;
     }
 }


### PR DESCRIPTION
One value was set incorrectly according to the rules and the fix which at least was tested on all GameController in Bordeaux was implemented to reflect the correct timing in Knock-Out-Games according to the rules.