### PR TITLE
Reducing penalty serving from 30s to 10s

### DIFF
--- a/src/controller/ui/ui/components/Robot.java
+++ b/src/controller/ui/ui/components/Robot.java
@@ -64,7 +64,7 @@ public class Robot extends AbstractComponent {
     private static final String UNKNOWN_ONLINE_STATUS = "wlan_status_grey.png";
     public static final Color COLOR_HIGHLIGHT = Color.YELLOW;
 
-    private static final int UNPEN_HIGHLIGHT_SECONDS = 10;
+    private static final int UNPEN_HIGHLIGHT_SECONDS = 5;
 
 
     public Robot(Side side, int id) {

--- a/src/data/values/Penalties.java
+++ b/src/data/values/Penalties.java
@@ -12,9 +12,9 @@ public enum Penalties implements DocumentingMarkdown {
     SUBSTITUTE(14, "substitute", -1), // TODO check if different for SPL than HL and what value is
     MANUAL(15, "manual", -1), // TODO check if different for SPL than HL and what value is
 
-    HL_BALL_MANIPULATION(30, "ball_manipulation", 30),
-    HL_PHYSICAL_CONTACT(31, "pushing", 30),
-    HL_PICKUP_OR_INCAPABLE(34, "pickup/incapable", 30),
+    HL_BALL_MANIPULATION(30, "ball_manipulation", 10),
+    HL_PHYSICAL_CONTACT(31, "pushing", 10),
+    HL_PICKUP_OR_INCAPABLE(34, "pickup/incapable", 10),
     HL_SERVICE(35, "service", 60);
 
     private byte byte_value;


### PR DESCRIPTION
Penalty serving was reduced from 30s to 10s in the rules, which is not reflected in this GameController

This PR reduces the penalty durations, and gets the yellow-blinking to start when 5s are remaining instead of 10.

See: https://github.com/RoboCup-Humanoid-TC/Rules/pull/75/files

![image](https://github.com/user-attachments/assets/b43f4485-ee40-495f-97fa-e24ef5790975)


